### PR TITLE
Fix logger->error in Agreements

### DIFF
--- a/Controller/Processing/Agreements.php
+++ b/Controller/Processing/Agreements.php
@@ -90,7 +90,7 @@ class Agreements implements HttpGetActionInterface
         if (is_array($response) && $response['result'] == 'OK') {
             $resultJson->setData($response['regulationList']);
         } else {
-            $this->logger->addError('Unable to get agreements.', [
+            $this->logger->error('Unable to get agreements.', [
                 'gatewayId' => $gatewayId,
                 'currency' => $currency,
                 'locale' => $locale,


### PR DESCRIPTION
```
Call to undefined method BlueMedia\\BluePayment\\Logger\\Logger::addError() at /data/web/magento_pl_staging/releases/28/vendor/bluepayment-plugin/module-bluepayment/Controller/Processing/Agreements.php:93)"} []
```