### PR TITLE
fix frame payment renderer component

### DIFF
--- a/view/frontend/web/js/view/payment/bluepayment.js
+++ b/view/frontend/web/js/view/payment/bluepayment.js
@@ -19,7 +19,7 @@ define([
     // Prepend - only frame
     rendererList.push({
         type: bluepaymentType + '-prepend',
-        component: 'uiComponent',
+        component: 'Magento_Checkout/js/view/payment/default',
         config: {
             template: 'BlueMedia_BluePayment/payment/bluepayment-prepend',
         },
@@ -91,7 +91,7 @@ define([
     // Append - only frame
     rendererList.push({
         type: bluepaymentType + '-append',
-        component: 'uiComponent',
+        component: 'Magento_Checkout/js/view/payment/default',
         config: {
             template: 'BlueMedia_BluePayment/payment/bluepayment-append',
         },


### PR DESCRIPTION
Magento w pewnych sytuacjach wymaga aby payment renderer miało metody, których `bluepayment-prepend` i `bluepayment-append` nie mają.

Przykładowy scenariusz, zakładający że żadna z metod płatności bluepayment nie jest dostępna dla metod dostawy za pobraniem:
1. Uzupełnienie adresu dostawy oraz wybór metody dostawy (innej niż za pobraniem).
2. Przejście do następnego kroku.
3. Wybór jednej z metod płatności bluepayment.
4. Powrót do poprzedniego kroku.
5. Zmiana metody dostawy na jakąkolwiek "za pobraniem".
6. Przejście do następnego kroku (tutaj błąd).

Użytkownik nie może przejść dalej, a w konsoli zobaczymy błąd z `magento/module-checkout/view/frontend/web/js/view/payment/list.js` [`removeRenderer`] - wykonywane jest tam na naszych rendererach `disposeSubscriptions()`, a takiej metody nie mamy.

Zmieniłem komponent tych rendererów z `uiComponent` na `Magento_Checkout/js/view/payment/default` i to rozwiązuje ten problem.